### PR TITLE
在庫カレンダー画面

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -121,14 +121,14 @@ public class StockController {
             // 登録処理
             stockService.update(id, stockDto);
 
-            return "stock/index";
+            return "redirect:/stock/index";
         } catch (Exception e) {
             log.error(e.getMessage());
 
             ra.addFlashAttribute("stockDto", stockDto);
             ra.addFlashAttribute("org.springframework.validation.BindingResult.stockDto", result);
 
-            return "redirect:/stock/edit";
+            return "stock/edit";
         }
     }
 
@@ -143,13 +143,13 @@ public class StockController {
         Integer daysInMonth = startDate.lengthOfMonth();
 
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        // List<String> books = this.stockService.
+        List<List<String>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
 
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
-
         model.addAttribute("stocks", stocks);
 
         return "stock/calendar";

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -1,9 +1,15 @@
 package jp.co.metateam.library.repository;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.Map;
+
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
@@ -20,4 +26,11 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 	Optional<Stock> findById(String id);
     
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+
+    @Query("SELECT s.bookMst.title AS bookTitle, COUNT(s) AS stockCount FROM Stock s WHERE s.status = 0 AND s.deletedAt IS NULL GROUP BY s.bookMst.title")
+    List<Map<String, Object>> findAvailableStocksByBook();
+
+    @Query(value = "SELECT COUNT(*) AS count FROM rental_manage rm JOIN stocks s ON rm.stock_id = s.id JOIN book_mst bm ON s.book_id = bm.id WHERE rm.expected_rental_on <= :day AND :day <= rm.expected_return_on AND bm.title = :title", nativeQuery = true)
+    Long findByUnAvailableCount(Date day, String title);
+
 }

--- a/src/main/resources/static/css/stock/calendar.css
+++ b/src/main/resources/static/css/stock/calendar.css
@@ -35,3 +35,11 @@
     padding: 5px;
     font-size: 14px;
 }
+
+#calendar_table tr.days th.saturday {
+    color: blue;
+}
+
+#calendar_table tr.days th.sunday {
+    color: red;
+}

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -22,23 +22,32 @@
                     <table id="calendar_table">
                         <colgroup>
                             <col style="width: 250px;">
-                            <col style="width: 80px;">
+                            <col style="width: 100px;">
                             <col style="width: 70px;" th:each="i : ${#numbers.sequence(0,daysInMonth)}">
                         </colgroup>
                         <thead>
                             <tr>
                                 <th class="header_book" rowspan="2">書籍名</th>
-                                <th class="header_stock" rowspan="2">在庫数</th>
+                                <th class="header_stock" rowspan="2">利用可能在庫数</th>
                                 <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
-                                <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
+                                <th th:each="day, iterStat : ${daysOfWeek}" 
+                                    th:text="${day}"
+                                    th:classappend="${#strings.contains(day, '土') ? 'saturday' : (#strings.contains(day, '日') ? 'sunday' : '')}">
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
+                            <tr th:each="bookValues : ${stocks}">
+                                <td th:text="${bookValues[0]}"></td>
+                                <td th:text="${bookValues[1]}"></td>
+                                <td th:each="value, iterStat : ${bookValues}" th:if="${iterStat.index > 2}" >
+                                    <span th:if="${value != '✖'}">
+                                        <a th:href="@{/rental/add(stockId=${bookValues[2]}, expectedRentalOn=${targetYear} + '-' + ${#numbers.formatInteger(targetMonth, 2)} + '-' + ${#numbers.formatInteger(iterStat.index - 2, 2)})}" th:text="${value}"></a>
+                                    </span>
+                                    <span th:unless="${value != '✖'}" th:text="${value}"></span>
+                                </td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
・概要
書籍名、利用可能在庫数、貸出可能数のテーブル作成
利用可能在庫数をリンク化し、貸出登録画面へ遷移
遷移した際に、在庫管理番号と貸出予定日が該当する書籍と日付を初期表示させる

・テスト証跡
テーブルが正しい表記をしているか
リンクを押下した際、貸出登録画面に遷移し、初期表示されているか
そのまま登録できるか
通常の貸出登録を押下した際に、変な初期表示がされていないか